### PR TITLE
Add Markdown Templates

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,3 @@
 exportPattern("(ClusterVCV|scale|Brattle|theme|gg|print)")
-
+export(brattle_html)
 import(ggplot2, grid, gridExtra, assertive, sandwich, viridis)

--- a/R/brattle_html.R
+++ b/R/brattle_html.R
@@ -1,0 +1,27 @@
+brattle_html <- function(toc = TRUE,
+                         toc_float = TRUE,
+                         number_sections = FALSE,
+                         fig_width = 8,
+                         fig_height = 6,
+                         fig_caption = TRUE,
+                         df_print = 'kable',
+                         code_folding = 'hide',
+                         ...
+                         ) {
+  css <- system.file("rmarkdown/templates/brattle_html/resources/brattle_html.css", package = "BrattleExtras")
+
+  # call the base html_document function
+  rmarkdown::html_document(fig_width = fig_width,
+                           fig_height = fig_height,
+                           fig_caption = fig_caption,
+                           highlight = NULL,
+                           theme = NULL,
+                           css = css,
+                           df_print = df_print,
+                           code_folding = code_folding,
+                           toc = toc,
+                           toc_float = toc_float,
+                           number_sections = number_sections,
+                           ...)
+
+}

--- a/inst/rmarkdown/templates/Brattle_HTML/resources/brattle_html.css
+++ b/inst/rmarkdown/templates/Brattle_HTML/resources/brattle_html.css
@@ -1,0 +1,51 @@
+/* _lcid="1033" _version="16.0.4266"
+_LocalBinding */
+/* pasted in */
+body
+{
+font-family:"Segoe UI","Segoe",Tahoma,Helvetica,Arial,sans-serif;
+font-size:13px;
+}
+h1,h2,h3,h4,h5,h6
+{
+margin:auto;
+font-weight:normal;
+}
+h1
+{
+font-family:"Segoe UI Light","Segoe UI","Segoe",Tahoma,Helvetica,Arial,sans-serif;
+font-size:2.3em;
+color:#777;
+font-weight:200;
+}
+h2,h3
+{
+font-family:"Segoe UI Semilight","Segoe UI","Segoe",Tahoma,Helvetica,Arial,sans-serif;
+color:#262626;
+font-weight:300;
+}
+h2
+{
+font-size:1.46em;
+}
+h3
+{
+font-size:1.15em;
+}
+h4,h5,h6
+{
+font-family:"Segoe UI","Segoe",Tahoma,Helvetica,Arial,sans-serif;
+}
+h4
+{
+font-size:1em;
+color:#262626;
+}
+h5
+{
+font-size:1em;
+}
+h6
+{
+font-size:1em;
+}

--- a/inst/rmarkdown/templates/Brattle_HTML/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/Brattle_HTML/skeleton/skeleton.Rmd
@@ -1,0 +1,38 @@
+---
+title: "Document Title"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    number_sections: false
+    theme: united
+    fig_width: 8
+    fig_height: 6
+    fig_caption: true
+    df_print: kable
+    code_folding: hide
+---
+
+***
+
+*PRIVILEGED AND CONFIDENTIAL*
+
+*PREPARED AT THE REQUEST OF COUNSEL*
+
+***
+
+# Overview
+
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE,
+                      warning = FALSE,
+                      message = FALSE)
+
+library(pacman)
+p_load(tidyverse, magrittr)
+p_load_gh('Brattle/BrattleExtras')
+```
+
+
+# Analysis

--- a/inst/rmarkdown/templates/Brattle_HTML/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/Brattle_HTML/skeleton/skeleton.Rmd
@@ -1,16 +1,6 @@
 ---
 title: "Document Title"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    number_sections: false
-    theme: united
-    fig_width: 8
-    fig_height: 6
-    fig_caption: true
-    df_print: kable
-    code_folding: hide
+output: BrattleExtras::brattle_html
 ---
 
 ***
@@ -23,11 +13,10 @@ output:
 
 # Overview
 
-
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = FALSE,
-                      warning = FALSE,
-                      message = FALSE)
+knitr::opts_chunk$set(echo = TRUE,
+                      warning = TRUE,
+                      message = TRUE)
 
 library(pacman)
 p_load(tidyverse, magrittr)

--- a/inst/rmarkdown/templates/Brattle_HTML/template.yaml
+++ b/inst/rmarkdown/templates/Brattle_HTML/template.yaml
@@ -1,0 +1,3 @@
+name: Brattle HTML
+description: >
+  Template for Brattle Markdown documents.

--- a/inst/rmarkdown/templates/Brattle_PDF/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/Brattle_PDF/skeleton/skeleton.Rmd
@@ -9,7 +9,6 @@ output:
     fig_caption: true
     df_print: kable
     keep_tex: true
-documentclass: brattlereport
 ---
 
 *PRIVILEGED AND CONFIDENTIAL*

--- a/inst/rmarkdown/templates/Brattle_PDF/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/Brattle_PDF/skeleton/skeleton.Rmd
@@ -1,0 +1,35 @@
+---
+title: "Document Title"
+output:
+  pdf_document:
+    toc: true
+    number_sections: false
+    fig_width: 8
+    fig_height: 6
+    fig_caption: true
+    df_print: kable
+    keep_tex: true
+documentclass: brattlereport
+---
+
+*PRIVILEGED AND CONFIDENTIAL*
+
+*PREPARED AT THE REQUEST OF COUNSEL*
+
+***
+
+# Overview
+
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE,
+                      warning = FALSE,
+                      message = FALSE)
+
+library(pacman)
+p_load(tidyverse, magrittr)
+p_load_gh('Brattle/BrattleExtras')
+```
+
+
+# Analysis

--- a/inst/rmarkdown/templates/Brattle_PDF/template.yaml
+++ b/inst/rmarkdown/templates/Brattle_PDF/template.yaml
@@ -1,0 +1,3 @@
+name: Brattle PDF
+description: >
+  Template for Brattle Markdown documents.


### PR DESCRIPTION
This pull adds placeholder RMarkdown templates for HTML and PDF. 

When the brattlereport.cls file is available, it can be used in the PDF markdown by adding "documentclass: brattlereport" to the header. 

For future consideration:

- Create an internal HTML memo template
- Create a custom CSS to choose fonts/theme
- Create a presentation HTML memo template
- Remove library(pacman), or do a check to automatically install pacman
- Consider defaults (e.g. ideal figure size, code folding)
